### PR TITLE
Add new PHP packages

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -10,6 +10,7 @@ RUN set -eux; \
   # Installing Just Build dependencies
   apt-get install -y --no-install-recommends \
     libfreetype6-dev \
+    libicu-dev \
     libjpeg-dev \
     libmemcached-dev \
     libpng-dev \
@@ -30,6 +31,7 @@ RUN set -eux; \
     memcached \
   ; \
   docker-php-ext-install -j "$(nproc)" \
+    intl \
     gd \
     opcache \
     pdo_mysql \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -10,6 +10,7 @@ RUN set -eux; \
   # Installing Just Build dependencies
   apt-get install -y --no-install-recommends \
     libfreetype6-dev \
+    libicu-dev \
     libjpeg-dev \
     libmemcached-dev \
     libpng-dev \
@@ -30,6 +31,7 @@ RUN set -eux; \
     memcached \
   ; \
   docker-php-ext-install -j "$(nproc)" \
+    intl \
     gd \
     opcache \
     pdo_mysql \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -10,6 +10,7 @@ RUN set -eux; \
   # Installing Just Build dependencies
   apt-get install -y --no-install-recommends \
     libfreetype6-dev \
+    libicu-dev \
     libjpeg-dev \
     libmemcached-dev \
     libpng-dev \
@@ -30,6 +31,7 @@ RUN set -eux; \
     memcached \
   ; \
   docker-php-ext-install -j "$(nproc)" \
+    intl \
     gd \
     opcache \
     pdo_mysql \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -10,6 +10,7 @@ RUN set -eux; \
   # Installing Just Build dependencies
   apt-get install -y --no-install-recommends \
     libfreetype6-dev \
+    libicu-dev \
     libjpeg-dev \
     libmemcached-dev \
     libpng-dev \
@@ -30,6 +31,7 @@ RUN set -eux; \
     memcached \
   ; \
   docker-php-ext-install -j "$(nproc)" \
+    intl \
     gd \
     opcache \
     pdo_mysql \


### PR DESCRIPTION
Added libicu-dev and intl extension in Dockerfiles

The libicu-dev package and intl PHP extension have been added in Dockerfiles for PHP versions 7.4, 8.0, 8.1, and 8.2. These additions provide enhanced internationalization support to the respective Docker environments.